### PR TITLE
Idle-by-default source, settings-driven device switching, in-place CMP/CCF reload

### DIFF
--- a/src/ezmsg/blackrock/cerelink.py
+++ b/src/ezmsg/blackrock/cerelink.py
@@ -6,16 +6,38 @@ import asyncio
 import logging
 import time
 import typing
+from dataclasses import dataclass
 
 import ezmsg.core as ez
 import numpy as np
 from ezmsg.baseproc.processor import BaseProducer
-from ezmsg.baseproc.units import BaseProducerUnit
+from ezmsg.baseproc.units import BaseProducerUnit, get_base_producer_type
 from ezmsg.event.message import EventMessage
 from ezmsg.util.messages.axisarray import AxisArray, replace
 from pycbsdk import ChannelType, DeviceType, SampleRate, Session
 
 logger = logging.getLogger(__name__)
+
+
+def _device_label(device_type: DeviceType | None) -> str:
+    """Human-readable name for a device, or ``"None"`` for the idle case."""
+    return device_type.name if device_type is not None else "None"
+
+
+@dataclass
+class DeviceStatus:
+    """Result of a settings-driven device switch.
+
+    Emitted on ``CereLinkSource.OUTPUT_DEVICE_STATUS`` after each ``on_settings``
+    background ``open()`` attempt. The GUI consumes this to confirm or revert
+    its device selection (the snapshot's settings_changed event fires before
+    the open completes and so cannot distinguish success from failure).
+    """
+
+    device_type: DeviceType | None
+    success: bool
+    error: str = ""
+
 
 CHANNEL_DTYPE = np.dtype(
     [
@@ -29,8 +51,12 @@ CHANNEL_DTYPE = np.dtype(
 
 
 class CereLinkSettings(ez.Settings):
-    device_type: DeviceType = DeviceType.NPLAY
-    """Device type to connect to."""
+    device_type: DeviceType | None = None
+    """Device type to connect to. ``None`` = no Session — the unit produces
+    nothing until a real device is selected. This idle-by-default mode lets
+    a host app defer the cost of opening pycbsdk until the user picks a
+    device, which is useful on macOS where simultaneous Sessions exhaust
+    POSIX shared memory."""
 
     cbtime: bool = False
     """True = raw device nanoseconds/1e9, False = time.monotonic() via clock sync."""
@@ -86,7 +112,14 @@ class CereLinkProducer(BaseProducer[CereLinkSettings, AxisArray]):
     # -- Lifecycle --
 
     def open(self) -> None:
-        """Create and start the Session, configure channels, register callbacks."""
+        """Create and start the Session, configure channels, register callbacks.
+
+        ``device_type=None`` is an explicit no-op — the producer stays idle
+        and ``_produce`` returns ``None`` on every call, which lets the unit
+        sit dormant until a real device is selected by the host app.
+        """
+        if self.settings.device_type is None:
+            return
         self._session = Session(device_type=self.settings.device_type)
         self._session.__enter__()
 
@@ -141,12 +174,62 @@ class CereLinkProducer(BaseProducer[CereLinkSettings, AxisArray]):
             self._handle_spike(header)
 
     def close(self) -> None:
-        """Tear down the Session."""
+        """Tear down the Session and unblock any in-flight ``_produce``.
+
+        The ``_data_event.set()`` is what frees a coroutine that may be
+        awaiting new samples — without it, an in-flight ``_produce`` from
+        the previous producer instance would block forever after a
+        settings-driven recreate, eventually getting GC'd as a pending task.
+        """
         if self._session is not None:
             self._session.__exit__(None, None, None)
             self._session = None
+        self._data_event.set()
 
     # -- Group setup --
+
+    def _build_ch_info(self, channels: list[int]) -> np.ndarray:
+        """Build the ``ch_info`` structured array (label/x/y/bank/elec) for one group."""
+        n_ch = len(channels)
+        ch_info = np.zeros(n_ch, dtype=CHANNEL_DTYPE)
+        for i, ch_id in enumerate(channels):
+            label = self._session.get_channel_label(ch_id)
+            ch_info[i]["label"] = label or f"ch{ch_id}"
+            pos = self._ch_positions.get(ch_id, (0, 0, 0, 0))
+            ch_info[i]["x"] = pos[0]
+            ch_info[i]["y"] = pos[1]
+            ch_info[i]["bank"] = chr(ord("A") + pos[2] - 1) if pos[2] > 0 else ""
+            ch_info[i]["elec"] = pos[3]
+        return ch_info
+
+    def reload_channel_map(self, cmp_path: str) -> None:
+        """Apply a new CMP to the existing Session, refresh cached positions,
+        and rebuild each active group's template so subsequent AxisArrays
+        carry the new (x, y) positions.
+
+        pycbsdk has no API to *clear* an applied CMP — pass ``None`` and
+        the call is a no-op with a warning.
+        """
+        if cmp_path is None:
+            logger.warning("CereLinkProducer.reload_channel_map: pycbsdk has no clear API; keeping previous map.")
+            return
+        self._session.load_channel_map(cmp_path, 0)
+        all_ids = self._session.get_matching_channel_ids(ChannelType.FRONTEND)
+        all_pos = self._session.get_channels_positions(ChannelType.FRONTEND)
+        self._ch_positions = dict(zip(all_ids, all_pos))
+        for rate_int, buf in self._buffers.items():
+            channels = self._session.get_group_channels(rate_int)
+            ch_info = self._build_ch_info(channels)
+            new_ch_ax = AxisArray.CoordinateAxis(data=ch_info, dims=["ch"], unit="struct")
+            old = buf["template"]
+            buf["template"] = replace(old, axes={**old.axes, "ch": new_ch_ax})
+
+    def reload_ccf(self, ccf_path: str) -> None:
+        """Apply a new CCF on the existing Session. ``None`` is a no-op."""
+        if ccf_path is None:
+            logger.warning("CereLinkProducer.reload_ccf: pycbsdk has no clear API; keeping previous CCF.")
+            return
+        self._session.load_ccf_sync(ccf_path)
 
     def _setup_group(self, rate: SampleRate, channels: list[int]) -> None:
         rate_int = int(rate)
@@ -154,18 +237,9 @@ class CereLinkProducer(BaseProducer[CereLinkSettings, AxisArray]):
         fs = rate.hz
         buff_samples = max(1, int(self.settings.cont_buffer_dur * fs))
 
-        ch_info = np.zeros(n_ch, dtype=CHANNEL_DTYPE)
+        ch_info = self._build_ch_info(channels)
         scale_factors = []
-        for i, ch_id in enumerate(channels):
-            label = self._session.get_channel_label(ch_id)
-            ch_info[i]["label"] = label or f"ch{ch_id}"
-
-            pos = self._ch_positions.get(ch_id, (0, 0, 0, 0))
-            ch_info[i]["x"] = pos[0]
-            ch_info[i]["y"] = pos[1]
-            ch_info[i]["bank"] = chr(ord("A") + pos[2] - 1) if pos[2] > 0 else ""
-            ch_info[i]["elec"] = pos[3]
-
+        for ch_id in channels:
             scaling = self._session.get_channel_scaling(ch_id)
             if scaling and scaling["digmax"] != scaling["digmin"]:
                 sf = (scaling["anamax"] - scaling["anamin"]) / (scaling["digmax"] - scaling["digmin"])
@@ -248,11 +322,20 @@ class CereLinkProducer(BaseProducer[CereLinkSettings, AxisArray]):
 
     # -- Data production (async, called by BaseProducerUnit loop) --
 
-    async def _produce(self) -> AxisArray:
+    async def _produce(self) -> AxisArray | None:
         if self._loop is None:
             self._loop = asyncio.get_running_loop()
 
         while True:
+            if self._session is None:
+                # No session — either we're idle (device_type=None) or a
+                # settings-driven recreate just closed us. Yield back to the
+                # event loop so other tasks (subscriber attach handlers, the
+                # next on_settings) can run, then return None so the unit's
+                # produce loop re-reads ``self.producer``. Without the sleep
+                # this becomes a tight loop that starves the asyncio scheduler.
+                await asyncio.sleep(0.1)
+                return None
             if not self._active_rates:
                 await asyncio.sleep(0.1)
                 continue
@@ -307,11 +390,166 @@ class CereLinkSource(BaseProducerUnit[CereLinkSettings, AxisArray, CereLinkProdu
 
     SETTINGS = CereLinkSettings
     OUTPUT_SPIKE = ez.OutputStream(EventMessage)
+    OUTPUT_DEVICE_STATUS = ez.OutputStream(DeviceStatus)
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        # Init here (not in ``initialize()``) so the queue exists before any
+        # publisher/subscriber coroutine could touch it. asyncio.Queue() in
+        # Python 3.10+ doesn't require a running loop.
+        self._status_queue: asyncio.Queue[DeviceStatus] = asyncio.Queue()
+
+    def _start_producer(self) -> None:
+        # Acquire the device session for the current producer. Called both at
+        # startup and after every settings-driven recreate so the new producer
+        # has a live Session before produce() runs.
+        self.producer._loop = asyncio.get_running_loop()
+        self.producer.open()
+        s = self.producer.settings
+        if s.device_type is None:
+            logger.info("CereLinkSource._start_producer: idle (no device selected)")
+            return
+        logger.info(
+            "CereLinkSource._start_producer: opened device=%s n_chans=%s sample_rate=%s",
+            s.device_type.name,
+            s.n_chans,
+            s.sample_rate.name if s.sample_rate is not None else None,
+        )
 
     async def initialize(self) -> None:
         self.create_producer()
-        self.producer._loop = asyncio.get_running_loop()
-        self.producer.open()
+        try:
+            self._start_producer()
+        except Exception as exc:
+            logger.exception("CereLinkSource.initialize: startup open() failed")
+            self._status_queue.put_nowait(
+                DeviceStatus(device_type=self.SETTINGS.device_type, success=False, error=str(exc))
+            )
+            return
+        self._status_queue.put_nowait(DeviceStatus(device_type=self.SETTINGS.device_type, success=True))
+
+    @ez.subscriber(BaseProducerUnit.INPUT_SETTINGS)
+    async def on_settings(self, msg: CereLinkSettings) -> None:
+        logger.info(
+            "CereLinkSource.on_settings: switching to device=%s n_chans=%s sample_rate=%s ccf=%s cmp=%s",
+            _device_label(msg.device_type),
+            msg.n_chans,
+            msg.sample_rate.name if msg.sample_rate is not None else None,
+            msg.ccf_path,
+            msg.cmp_path,
+        )
+        prev = self.SETTINGS
+
+        # Recreating a pycbsdk Session against the same physical device (and
+        # NPLAY in particular — single-client emulator) corrupts the new
+        # session via the old session's ``__exit__``. So if only CMP/CCF
+        # changed and we already have a working session, apply the change
+        # in-place rather than spawning a fresh producer.
+        needs_session_restart = (
+            msg.device_type != prev.device_type
+            or msg.n_chans != prev.n_chans
+            or msg.sample_rate != prev.sample_rate
+            or msg.channel_type != prev.channel_type
+            or msg.ac_input_coupling != prev.ac_input_coupling
+        )
+        if not needs_session_restart and getattr(self.producer, "_session", None) is not None:
+            asyncio.create_task(self._apply_in_place_settings(msg, prev))
+            return
+
+        # Build the new producer eagerly but don't open it yet — open() is
+        # synchronous and can block ~2s on a missing device. Doing that here
+        # would hold the INPUT_SETTINGS subscriber lease and time out the
+        # GUI's update_setting RPC. Defer to a background task so this
+        # subscriber returns immediately.
+        prev_producer = self.producer
+        producer_type = get_base_producer_type(self.__class__)
+        new_producer = producer_type(settings=msg)
+        new_producer._loop = asyncio.get_running_loop()
+        asyncio.create_task(self._finalize_settings_change(msg, prev_producer, new_producer))
+
+    async def _apply_in_place_settings(self, msg: CereLinkSettings, prev: CereLinkSettings) -> None:
+        """Apply CMP/CCF changes to the existing producer's Session."""
+        try:
+            if msg.ccf_path != prev.ccf_path:
+                await asyncio.to_thread(self.producer.reload_ccf, msg.ccf_path)
+            if msg.cmp_path != prev.cmp_path:
+                await asyncio.to_thread(self.producer.reload_channel_map, msg.cmp_path)
+        except Exception as exc:
+            logger.exception("CereLinkSource: in-place CMP/CCF reload failed")
+            await self._status_queue.put(DeviceStatus(device_type=msg.device_type, success=False, error=str(exc)))
+            return
+        # Update the producer's settings reference so subsequent reads match.
+        self.producer.settings = msg
+        self.apply_settings(msg)
+        await self._status_queue.put(DeviceStatus(device_type=msg.device_type, success=True))
+
+    async def _finalize_settings_change(
+        self,
+        new_settings: CereLinkSettings,
+        prev_producer: CereLinkProducer,
+        new_producer: CereLinkProducer,
+    ) -> None:
+        """Close prev, then open new — never two pycbsdk Sessions at once.
+
+        Overlapping Sessions exhaust POSIX shared memory on macOS when the
+        graph subprocess already has multiple ezmsg pubsub channels. We
+        accept a brief no-data window during the swap. If ``open()`` fails,
+        ``self.producer`` is left pointing at the (now-closed-and-empty) new
+        producer, ``self.SETTINGS`` is reset to a no-device config, and the
+        GUI receives a failure ``DeviceStatus`` so it can revert.
+
+        Queues a ``DeviceStatus`` on both success and failure — the
+        clearing-house's settings_changed event fires before this runs and
+        so cannot tell the GUI which way the open went.
+        """
+        # Park self.producer on the (still-unopened) new instance so the
+        # ``produce()`` loop's ``self.producer.__acall__()`` returns ``None``
+        # while we close prev / open new (CereLinkProducer._produce returns
+        # ``None`` whenever ``_session is None``).
+        self.producer = new_producer
+        try:
+            await asyncio.to_thread(prev_producer.close)
+        except Exception:
+            logger.exception("CereLinkSource: failed to close previous producer")
+
+        try:
+            await asyncio.to_thread(new_producer.open)
+        except Exception as exc:
+            logger.exception(
+                "CereLinkSource: failed to open device=%s",
+                _device_label(new_settings.device_type),
+            )
+            try:
+                new_producer.close()
+            except Exception:
+                logger.exception("CereLinkSource: failed to close half-opened producer")
+            # Fall back to a no-device state; the GUI will reconcile via the
+            # DeviceStatus failure event. ``new_producer._session`` is None
+            # (open failed before assignment) so ``_produce`` already returns
+            # None regardless of producer.settings — only self.SETTINGS needs
+            # to reflect the rollback for downstream observers.
+            self.apply_settings(replace(new_settings, device_type=None))
+            await self._status_queue.put(
+                DeviceStatus(
+                    device_type=new_settings.device_type,
+                    success=False,
+                    error=str(exc),
+                )
+            )
+            return
+
+        s = new_producer.settings
+        if s.device_type is None:
+            logger.info("CereLinkSource: now idle (no device)")
+        else:
+            logger.info(
+                "CereLinkSource: opened device=%s n_chans=%s sample_rate=%s",
+                s.device_type.name,
+                s.n_chans,
+                s.sample_rate.name if s.sample_rate is not None else None,
+            )
+        self.apply_settings(new_settings)
+        await self._status_queue.put(DeviceStatus(device_type=new_settings.device_type, success=True))
 
     def shutdown(self) -> None:
         self.producer.close()
@@ -321,3 +559,9 @@ class CereLinkSource(BaseProducerUnit[CereLinkSettings, AxisArray, CereLinkProdu
         while True:
             spike = await self.producer.spike_queue.get()
             yield self.OUTPUT_SPIKE, spike
+
+    @ez.publisher(OUTPUT_DEVICE_STATUS)
+    async def device_status(self) -> typing.AsyncGenerator:
+        while True:
+            status = await self._status_queue.get()
+            yield self.OUTPUT_DEVICE_STATUS, status

--- a/src/ezmsg/blackrock/cereplex_impedance.py
+++ b/src/ezmsg/blackrock/cereplex_impedance.py
@@ -9,6 +9,7 @@ Multiple headstages are tracked independently — each may be at a different poi
 in its impedance sweep.
 """
 
+import dataclasses
 import logging
 import typing
 
@@ -391,3 +392,39 @@ class CerePlexImpedance(
     ]
 ):
     SETTINGS = CerePlexImpedanceSettings
+
+    @ez.subscriber(BaseTransformerUnit.INPUT_SETTINGS)
+    async def on_settings(self, msg: CerePlexImpedanceSettings) -> None:
+        """Apply new settings.
+
+        If only ``headstage_channel_offsets`` changed, rebuild the trackers in
+        place — the accumulated impedance values for previously-measured
+        channels remain valid. Any other change recreates the processor as
+        usual (state is reset on the next message).
+        """
+        old = self.SETTINGS
+        if old is not None and isinstance(old, CerePlexImpedanceSettings):
+            old_offsets = tuple(old.headstage_channel_offsets)
+            new_offsets = tuple(msg.headstage_channel_offsets)
+            offsets_changed = old_offsets != new_offsets
+            # For the "everything else matches" check, normalise the offsets
+            # field on both sides before comparing the full dataclasses.
+            old_norm = dataclasses.replace(old, headstage_channel_offsets=new_offsets)
+            msg_norm = dataclasses.replace(msg, headstage_channel_offsets=new_offsets)
+            only_offsets = offsets_changed and old_norm == msg_norm
+        else:
+            only_offsets = False
+        self.apply_settings(msg)
+        proc = getattr(self, "processor", None)
+        state = getattr(proc, "state", None) if proc is not None else None
+        impedance = getattr(state, "impedance", None) if state is not None else None
+        if only_offsets and impedance is not None:
+            proc.settings = msg
+            proc._build_trackers(impedance.shape[0])
+            logger.info(
+                "CerePlexImpedance.on_settings: rebuilt trackers (offsets=%s); preserved %d impedance values.",
+                msg.headstage_channel_offsets,
+                impedance.shape[0],
+            )
+        else:
+            self.create_processor()

--- a/src/ezmsg/blackrock/cereplex_impedance.py
+++ b/src/ezmsg/blackrock/cereplex_impedance.py
@@ -173,15 +173,26 @@ class CerePlexImpedanceProcessor(
         s.max_buffer_samples = int(settings.collect_duration_s * s.fs)
         s.fft_samples = int(settings.fft_duration_s * s.fs)
 
-        offsets = sorted(settings.headstage_channel_offsets)
+        self._build_trackers(n_ch)
+
+        s.impedance = np.full(n_ch, np.nan, dtype=np.float64)
+        s.ch_axis = message.axes.get("ch")
+
+    def _build_trackers(self, n_ch: int) -> None:
+        """Build per-headstage trackers from the current settings.
+
+        Split out from ``_reset_state`` so a settings update that only changes
+        ``headstage_channel_offsets`` can rebuild the tracker layout without
+        clearing the accumulated ``state.impedance`` array. Any in-flight
+        per-tracker burst buffer is discarded; new bursts buffer fresh.
+        """
+        s = self.state
+        offsets = sorted(self.settings.headstage_channel_offsets)
         s.trackers = []
         for i, start in enumerate(offsets):
             end = offsets[i + 1] if i + 1 < len(offsets) else n_ch
             buf = np.zeros(s.max_buffer_samples, dtype=np.float64)
             s.trackers.append(_HeadstageTracker(start, end, buf))
-
-        s.impedance = np.full(n_ch, np.nan, dtype=np.float64)
-        s.ch_axis = message.axes.get("ch")
 
     # --- Per-headstage helpers ---
 

--- a/src/ezmsg/blackrock/cereplex_impedance.py
+++ b/src/ezmsg/blackrock/cereplex_impedance.py
@@ -9,6 +9,7 @@ Multiple headstages are tracked independently — each may be at a different poi
 in its impedance sweep.
 """
 
+import logging
 import typing
 
 import ezmsg.core as ez
@@ -16,6 +17,8 @@ import numpy as np
 import scipy.signal as ss
 from ezmsg.baseproc import BaseStatefulTransformer, BaseTransformerUnit, processor_state
 from ezmsg.util.messages.axisarray import AxisArray, replace
+
+logger = logging.getLogger(__name__)
 
 
 class CerePlexImpedanceSettings(ez.Settings):
@@ -356,11 +359,17 @@ class CerePlexImpedanceProcessor(
         if n_time == 0:
             return None
 
+        # Capture if ch_axis changed for later emission even if no update
+        incoming_ch = message.axes.get("ch")
+        ch_axis_changed = incoming_ch is not None and incoming_ch is not s.ch_axis
+        if ch_axis_changed:
+            s.ch_axis = incoming_ch
+
         any_updated = False
         for hs in s.trackers:
             any_updated |= self._process_headstage(data, n_time, hs)
 
-        if any_updated:
+        if any_updated or ch_axis_changed:
             time_ix = message.get_axis_idx("time")
             new_time_ax = replace(
                 message.axes["time"], offset=message.axes["time"].value(message.data.shape[time_ix] - 1)


### PR DESCRIPTION
## Summary

Reworks `CereLinkSource` so it can be driven by runtime settings changes (device type, CMP/CCF) without restarting the host process, and adds the `OUTPUT_DEVICE_STATUS` stream that tells the GUI whether each switch actually succeeded.

Also tweaks `CerePlexImpedance` so a CMP load on the upstream source re-emits impedance values immediately (so downstream consumers pick up the new positions) and so `headstage_channel_offsets` updates rebuild trackers without dropping the accumulated impedance buffer.

## What changed

### `CereLinkSettings`

- `device_type` is now `DeviceType | None`, defaulting to `None`. The unit starts idle and produces nothing until the host app pushes a real device. Motivation: opening a pycbsdk Session at startup and then overlapping it with a swap to another device blows macOS POSIX shm per-process limits and instant-fails with "Shared memory error". Idle default + close-then-open (below) keeps Session count at most 1.

### `CereLinkProducer`

- `open()` is a no-op when `device_type is None`.
- `close()` now also `_data_event.set()`s — frees an in-flight `_produce` coroutine that would otherwise block forever after a recreate and get GC'd as a pending task.
- `_produce()` returns `None` (with a brief `await asyncio.sleep(0.1)`) when `_session is None` instead of returning immediately. Without the sleep the produce loop tight-spins and starves the asyncio scheduler — which actually surfaced as "subscriber attach timeout" on the host side.
- New `reload_channel_map(cmp_path)` and `reload_ccf(ccf_path)` apply metadata-only changes to the existing Session instead of recreating it. pycbsdk has no "clear CMP" API; passing `None` is a no-op + warning. Refresh `_ch_positions` and rebuild each active group's `template` ch-axis so subsequent AxisArrays carry the new positions.
- Refactor: extract `_build_ch_info(channels)` from `_setup_group` so it can be reused by `reload_channel_map`.

### `CereLinkSource`

- New `OUTPUT_DEVICE_STATUS` stream (`DeviceStatus(device_type, success, error)`). Emitted on every settings-driven open attempt. Needed because the clearing-house's `settings_changed` event fires on receipt, before the open has actually run, and so can't tell the GUI which way it went.
- `on_settings` overridden to:
  - Detect "metadata-only" changes (CMP / CCF only) and apply in-place via `_apply_in_place_settings` — no Session recreate, no overlap.
  - For real device changes, spawn a background task (`_finalize_settings_change`) that closes the previous producer *before* opening the new one. Keeps the in-process pycbsdk Session count at most 1 at any moment.
  - Returns immediately so the INPUT_SETTINGS subscriber lease releases — otherwise pycbsdk's slow `Session()` call (~2s on missing device) would hold the lease past the host's `update_setting` RPC timeout.
- On open() failure: roll back to a no-device state and emit a failure `DeviceStatus`. Host GUI can react (e.g., revert the dropdown).
- `__init__` initializes `_status_queue` so it's available before any publisher coroutine could touch it.

### `CerePlexImpedance`

- `_reset_state` split into the metadata setup and a separate `_build_trackers(n_ch)`, so an `on_settings` that only changes `headstage_channel_offsets` rebuilds trackers without clearing the accumulated `state.impedance` array.
- Added an `on_settings` override that takes the in-place tracker-rebuild path when only `headstage_channel_offsets` changed, and falls through to the default recreate otherwise.
- In `_aprocess`, detect ch-axis identity change (CMP load upstream) and re-emit current `state.impedance` immediately, so a host GUI sees the new electrode positions without waiting for the next burst completion (which can take seconds for headstages with many channels).

## Why this matters

Before this PR, the only way to change the device or load a CMP after startup was to restart the host process. That made the impedance and timeseries GUIs unusable for any workflow that involves comparing configurations or recovering from a wrong initial selection.